### PR TITLE
Add command line flag parsing using clap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0"
 cargo-subcommand-metadata = "0.1"
+clap = { version = "3.2.5", features = ["deprecated", "derive", "wrap_help"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::or_fun_call)]
 
 use anyhow::{Context, Result};
+use clap::Parser;
 use serde::Deserialize;
 use std::env;
 use std::ffi::OsString;
@@ -10,12 +11,21 @@ use std::process::{self, Command, Stdio};
 
 cargo_subcommand_metadata::description!("Remove Cargo.lock lockfile");
 
+#[derive(Parser, Debug)]
+#[clap(name = "cargo-rm", bin_name = "cargo", author, version)]
+enum Cli {
+    #[clap(name = "rm", author, version, about = "Remove Cargo.lock lockfile")]
+    Rm {},
+}
+
 #[derive(Deserialize)]
 struct Metadata {
     workspace_root: PathBuf,
 }
 
 fn main() -> Result<()> {
+    let _ = Cli::parse();
+
     let cargo = env::var_os("CARGO").unwrap_or(OsString::from("cargo"));
     let output = Command::new(cargo)
         .arg("metadata")


### PR DESCRIPTION
This provides an easy implementation of `--version` and `--help`, and will support `--manifest-path` in a future PR.